### PR TITLE
fix: fixes default for Storybook modes

### DIFF
--- a/apps/demo/.storybook/preview.ts
+++ b/apps/demo/.storybook/preview.ts
@@ -46,7 +46,7 @@ const preview: Preview = {
     breakpoints: {
       name: "Breakpoints",
       description: "Breakpoints for Components",
-      defaultValue: "default",
+      defaultValue: "desktop",
       toolbar: {
         title: "Breakpoint",
         icon: "mobile",


### PR DESCRIPTION
sets the default breakpoint to desktop in Storybook